### PR TITLE
BUGFIX: htmls need the latest version in source

### DIFF
--- a/py/escher/urls.py
+++ b/py/escher/urls.py
@@ -23,10 +23,12 @@ _escher_web = {
                                          __map_model_version__),
 }
 
+# NOTE: the last js were for version 1.7.3
+VERSION = "1.7.3"
 _dependencies_cdn = {
-    'escher': 'https://unpkg.com/escher@%s/dist/escher.js' % __version__,
+    'escher': 'https://unpkg.com/escher@%s/dist/escher.js' % VERSION,
     'escher_min': ('https://unpkg.com/escher@%s/dist/escher.min.js' %
-                   __version__),
+                   VERSION),
 }
 
 _links = {


### PR DESCRIPTION
When saving htmls, the script src needs to be force to 1.7.3, otherwise the htmls will not render


In this file, change in line 6, the version to `1.7.3` instead of `1.7.4` and it should render properly
[test_map.html.txt](https://github.com/Toepfer-Lab/escher-legacy/files/14331426/test_map.html.txt)
